### PR TITLE
Fix handling of responses that do not end with a delimiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Determine if HTTP cookies will be sent along with the request, one of `same-orig
 A function which implements the following interface:
 
 ```js
-(rawChunk, previousChunkSuffix) => [ parsedChunk, chunkSuffix ]
+(rawChunk, previousChunkSuffix, isFinalChunk) => [ parsedChunk, chunkSuffix ]
 ```
 
 The `chunkParser` takes the raw, textual chunk response returned by the server and converts it into the value passed to the `onChunk` callback (see `options.onChunk`).  The function may also yield an optional chunkSuffix which will be not be passed to the `onChunk` callback but will instead be supplied as the `previousChunkSuffix` value the next time the `chunkParser` is invoked.
@@ -60,6 +60,8 @@ The `chunkParser` takes the raw, textual chunk response returned by the server a
 If the `chunkParser` throws an exception, the chunk will be discarded and the error that was raised will be passed to the `onChunk` callback augmented with a `rawChunk` property consisting of the textual chunk for logging / recovery.
 
 If no `chunkParser` is supplied the `defaultChunkParser` will be used which expects the chunks returned by the server to consist of one or more `\n` delimited lines of JSON object literals which are parsed into an Array.
+
+`chunkParser` will be called with `isFinalChunk` as `true` when the response has completed and there was a non-empty `chunkSuffix` from the last chunk. The `rawChunk` will be an empty string and the `previousChunkSuffix` will be the last returned `chunkSuffix`.
 
 #### onChunk (optional)
 A function which implements the following interface:

--- a/src/defaultChunkParser.js
+++ b/src/defaultChunkParser.js
@@ -8,13 +8,13 @@ const entryDelimiter = '\n';
 //
 // It will correctly handle the case where a chunk is emitted by the server across
 // delimiter boundaries.
-export default function defaultChunkParser(rawChunk, prevChunkSuffix = '') {
+export default function defaultChunkParser(rawChunk, prevChunkSuffix = '', isFinalChunk = false) {
   let chunkSuffix;
 
   const rawChunks = `${prevChunkSuffix}${rawChunk}`
     .split(entryDelimiter);
 
-  if (!hasSuffix(rawChunk, entryDelimiter)) {
+  if (!isFinalChunk && !hasSuffix(rawChunk, entryDelimiter)) {
     chunkSuffix = rawChunks.pop();
   }
 

--- a/src/impl/fetch.js
+++ b/src/impl/fetch.js
@@ -4,14 +4,14 @@ export const READABLE_BYTE_STREAM = 'readable-byte-stream';
 
 export default function fetchRequest(options) {
   const decoder = new TextDecoder();
-  const { onRawChunk, onComplete, method, body, credentials } = options;
+  const { onRawChunk, onRawComplete, method, body, credentials } = options;
   const headers = marshallHeaders(options.headers);
 
   function pump(reader, res) {
     return reader.read()
       .then(result => {
         if (result.done) {
-          return onComplete({
+          return onRawComplete({
             statusCode: res.status,
             transport: READABLE_BYTE_STREAM,
             raw: res

--- a/src/impl/mozXhr.js
+++ b/src/impl/mozXhr.js
@@ -15,7 +15,7 @@ export default function mozXhrRequest(options) {
   }
 
   function onLoadEvent() {
-    options.onComplete({
+    options.onRawComplete({
       statusCode: xhr.status,
       transport: MOZ_CHUNKED,
       raw: xhr

--- a/src/impl/xhr.js
+++ b/src/impl/xhr.js
@@ -11,7 +11,7 @@ export default function xhrRequest(options) {
   }
 
   function onLoadEvent() {
-    options.onComplete({
+    options.onRawComplete({
       statusCode: xhr.status,
       transport: XHR,
       raw: xhr

--- a/src/index.js
+++ b/src/index.js
@@ -42,8 +42,10 @@ export default function chunkedRequest(options) {
   }
 
   function processRawComplete(rawComplete) {
-    // Call the parser with isFinalChunk=true to flush the suffix
-    processRawChunk("", true);
+    if( prevChunkSuffix != "") {
+      // Call the parser with isFinalChunk=true to flush the prevChunkSuffix
+      processRawChunk("", true);
+    }
     onComplete(rawComplete);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,21 +22,29 @@ export default function chunkedRequest(options) {
 
   let prevChunkSuffix = "";
 
-  function processRawChunk(rawChunk) {
+  function processRawChunk(rawChunk, isFinalChunk = false) {
     let parsedChunks = null;
     let parseError = null;
     let suffix = "";
 
     try {
-      [ parsedChunks, suffix ] = chunkParser(rawChunk, prevChunkSuffix);
+      [ parsedChunks, suffix ] = chunkParser(rawChunk, prevChunkSuffix, isFinalChunk);
       prevChunkSuffix = suffix || "";
     } catch (e) {
       parseError = e;
       parseError.rawChunk = rawChunk;
       parseError.prevChunkSuffix = prevChunkSuffix;
     } finally {
-      onChunk(parseError, parsedChunks);
+      if (parseError || (parsedChunks!=null && parsedChunks.length > 0) ) {
+        onChunk(parseError, parsedChunks);
+      }
     }
+  }
+
+  function processRawComplete(rawComplete) {
+    // Call the parser with isFinalChunk=true to flush the suffix
+    processRawChunk("", true);
+    onComplete(rawComplete);
   }
 
   let transport = options.transport;
@@ -50,8 +58,8 @@ export default function chunkedRequest(options) {
     method,
     body,
     credentials,
-    onComplete,
-    onRawChunk: processRawChunk
+    onRawChunk: processRawChunk,
+    onRawComplete: processRawComplete
   });
 }
 


### PR DESCRIPTION
This change fixes the handling of responses that do not end with a delimiter.
